### PR TITLE
feat: remove model validation to support any AI model

### DIFF
--- a/enhancement_model_validation_test.go
+++ b/enhancement_model_validation_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -198,17 +197,20 @@ func TestModelValidationWithConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid models", func(t *testing.T) {
-		invalidModels := []string{
-			"gpt-4",
-			"not-claude",
-			"claude", // Too short
+	t.Run("any models now accepted", func(t *testing.T) {
+		anyModels := []string{
+			"gpt-4",         // Now accepted - OpenAI model
+			"not-claude",    // Now accepted - custom model
+			"claude",        // Now accepted - simple name
+			"kimi",          // Now accepted - Kimi model
+			"deepseek",      // Now accepted - DeepSeek model
+			"glm-4",         // Now accepted - GLM model
 		}
 
-		for _, model := range invalidModels {
+		for _, model := range anyModels {
 			err := validateModel(model)
-			if err == nil {
-				t.Errorf("validateModel('%s') should have failed", model)
+			if err != nil {
+				t.Errorf("validateModel('%s') should now be accepted: %v", model, err)
 			}
 		}
 	})
@@ -298,14 +300,14 @@ func TestEnvironmentValidationWithModel(t *testing.T) {
 			false,
 		},
 		{
-			"invalid model in environment",
+			"any model in environment now accepted",
 			Environment{
 				Name:   "test",
 				URL:    "https://api.anthropic.com",
 				APIKey: "sk-ant-test123456789",
-				Model:  "invalid-model",
+				Model:  "any-model-name",
 			},
-			true,
+			false, // Now accepted
 		},
 	}
 
@@ -320,12 +322,7 @@ func TestEnvironmentValidationWithModel(t *testing.T) {
 				t.Errorf("Unexpected validation error: %v", err)
 			}
 			
-			// Check that model-specific errors are properly identified
-			if tc.expectError && err != nil {
-				if !strings.Contains(err.Error(), "model") {
-					t.Errorf("Expected model-related error, got: %v", err)
-				}
-			}
+			// Note: Model validation is now disabled, so no model-specific errors expected
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -279,10 +279,9 @@ func validateAPIKey(apiKey string) error {
 	return nil
 }
 
-// validateModel validates Anthropic model naming conventions with adaptive behavior
+// validateModel allows any model name (no validation)
 func validateModel(model string) error {
-	validator := newModelValidator()
-	return validator.validateModelAdaptive(model)
+	return nil // Accept any model name including Kimi, DeepSeek, GLM, etc.
 }
 
 // validateModelAdaptive performs adaptive model validation with graceful degradation


### PR DESCRIPTION
Removes all model validation restrictions to support any AI model including Kimi, DeepSeek, GLM, OpenAI, etc.

## Changes
- Remove model validation restrictions from validateModel() function
- Now accepts any model name including Kimi, DeepSeek, GLM, OpenAI models, etc.
- Update tests to reflect that all model names are now accepted
- Fix unused imports in test files

## Impact
Before: Only specific Claude model formats were allowed
After: Any model name is accepted without validation

Fixes #4

Generated with [Claude Code](https://claude.ai/code)